### PR TITLE
Merging Rust STD side of std-fs integration

### DIFF
--- a/library/std/src/sys/hermit/fd.rs
+++ b/library/std/src/sys/hermit/fd.rs
@@ -26,7 +26,7 @@ impl FileDesc {
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
-        let result = cvt(unsafe { abi::write(self.fd.as_raw_fd(), buf.as_mut_ptr(), buf.len()) })?;
+        let result = cvt(unsafe { abi::write(self.fd.as_raw_fd(), buf.as_ptr(), buf.len()) })?;
         Ok(result as usize)
     }
 

--- a/library/std/src/sys/hermit/fd.rs
+++ b/library/std/src/sys/hermit/fd.rs
@@ -26,7 +26,7 @@ impl FileDesc {
     }
 
     pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
-        let result = cvt(unsafe { abi::write(self.fd.as_raw_fd(), buf.as_ptr(), buf.len()) })?;
+        let result = cvt(unsafe { abi::write(self.fd.as_raw_fd(), buf.as_mut_ptr(), buf.len()) })?;
         Ok(result as usize)
     }
 

--- a/library/std/src/sys/twizzler/fd.rs
+++ b/library/std/src/sys/twizzler/fd.rs
@@ -1,0 +1,84 @@
+use crate::io::{self, Read, SeekFrom};
+use crate::io::SeekFrom::{Start, Current, End};
+
+use crate::sys::unsupported;
+use twizzler_runtime_api::OwnedFd;
+use crate::sys_common::IntoInner;
+use crate::sys_common::FromInner;
+
+use twizzler_runtime_api::SeekFrom as InnerSeek;
+use twizzler_runtime_api::SeekFrom::{Start as InnerStart, Current as InnerCurrent, End as InnerEnd};
+
+// A abstraction that can do continious IO on a set of Twizzler objects
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub struct FileDesc {
+    pub fd: OwnedFd
+}
+
+impl FileDesc {
+    pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
+        let runtime = twizzler_runtime_api::get_runtime();
+
+        let result = runtime.read(self.fd, buf.as_mut_ptr(), buf.len()).expect("Read");
+
+        Ok(result as usize)
+    }
+
+    pub fn read_to_end(&self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        let mut me = self;
+        (&mut me).read_to_end(buf)
+    }
+
+    pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
+        let runtime = twizzler_runtime_api::get_runtime();
+
+        let result = runtime.write(self.fd, buf.as_ptr(), buf.len()).expect("Write");
+        
+        Ok(result as usize)
+    }
+
+    pub fn seek(&self, pos: SeekFrom) -> io::Result<u64> {
+        let runtime = twizzler_runtime_api::get_runtime();
+
+        let inner: InnerSeek = match pos {
+            Start(x) => InnerSeek::Start(x),
+            End(x) => InnerSeek::End(x),
+            Current(x) => InnerSeek::Current(x),
+        };
+
+        let result = runtime.seek(self.fd, inner).expect("Seek");
+
+        Ok(result as u64)
+    }
+
+    pub fn duplicate(&self) -> io::Result<FileDesc> {
+        self.duplicate_path(&[])
+    }
+    pub fn duplicate_path(&self, _path: &[u8]) -> io::Result<FileDesc> {
+        unsupported()
+    }
+
+    pub fn nonblocking(&self) -> io::Result<bool> {
+        Ok(false)
+    }
+
+    pub fn set_cloexec(&self) -> io::Result<()> {
+        unsupported()
+    }
+
+    pub fn set_nonblocking(&self, _nonblocking: bool) -> io::Result<()> {
+        unsupported()
+    }
+}
+
+impl IntoInner<OwnedFd> for FileDesc {
+    fn into_inner(self) -> OwnedFd {
+        self.fd
+    }
+}
+
+impl FromInner<OwnedFd> for FileDesc {
+    fn from_inner(owned_fd: OwnedFd) -> Self {
+        Self { fd: owned_fd }
+    }
+}

--- a/library/std/src/sys/twizzler/fd.rs
+++ b/library/std/src/sys/twizzler/fd.rs
@@ -96,3 +96,9 @@ impl FromInner<RawFd> for FileDesc {
         Self { fd: owned_fd }
     }
 }
+
+impl core::fmt::Display for FileDesc {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "FileDesc({:x})", self.fd)
+    }
+}

--- a/library/std/src/sys/twizzler/fs.rs
+++ b/library/std/src/sys/twizzler/fs.rs
@@ -1,0 +1,371 @@
+use crate::ffi::OsString;
+use crate::fmt;
+use crate::hash::{Hash, Hasher};
+use crate::collections::hash_map::DefaultHasher;
+use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut, SeekFrom, Error};
+use crate::sys::common::small_c_string::run_path_with_cstr;
+use crate::path::{Path, PathBuf};
+use crate::sys::time::SystemTime;
+use crate::sys::unsupported;
+use core::ffi::CStr;
+use crate::sys::fd::FileDesc;
+
+pub struct File(FileDesc);
+
+pub struct FileAttr(!);
+
+pub struct ReadDir(!);
+
+pub struct DirEntry(!);
+
+#[derive(Clone, Debug)]
+pub struct OpenOptions {
+    // generic
+    read: bool,
+    write: bool,
+    append: bool,
+    truncate: bool,
+    create: bool,
+    create_new: bool,
+    // system-specific
+    mode: i32,
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct FileTimes {}
+
+pub struct FilePermissions(!);
+
+pub struct FileType(!);
+
+#[derive(Debug)]
+pub struct DirBuilder {}
+
+impl FileAttr {
+    pub fn size(&self) -> u64 {
+        self.0
+    }
+
+    pub fn perm(&self) -> FilePermissions {
+        self.0
+    }
+
+    pub fn file_type(&self) -> FileType {
+        self.0
+    }
+
+    pub fn modified(&self) -> io::Result<SystemTime> {
+        self.0
+    }
+
+    pub fn accessed(&self) -> io::Result<SystemTime> {
+        self.0
+    }
+
+    pub fn created(&self) -> io::Result<SystemTime> {
+        self.0
+    }
+}
+
+impl Clone for FileAttr {
+    fn clone(&self) -> FileAttr {
+        self.0
+    }
+}
+
+impl FilePermissions {
+    pub fn readonly(&self) -> bool {
+        self.0
+    }
+
+    pub fn set_readonly(&mut self, _readonly: bool) {
+        self.0
+    }
+}
+
+impl Clone for FilePermissions {
+    fn clone(&self) -> FilePermissions {
+        self.0
+    }
+}
+
+impl PartialEq for FilePermissions {
+    fn eq(&self, _other: &FilePermissions) -> bool {
+        self.0
+    }
+}
+
+impl Eq for FilePermissions {}
+
+impl fmt::Debug for FilePermissions {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0
+    }
+}
+
+impl FileTimes {
+    pub fn set_accessed(&mut self, _t: SystemTime) {}
+    pub fn set_modified(&mut self, _t: SystemTime) {}
+}
+
+impl FileType {
+    pub fn is_dir(&self) -> bool {
+        self.0
+    }
+
+    pub fn is_file(&self) -> bool {
+        self.0
+    }
+
+    pub fn is_symlink(&self) -> bool {
+        self.0
+    }
+}
+
+impl Clone for FileType {
+    fn clone(&self) -> FileType {
+        self.0
+    }
+}
+
+impl Copy for FileType {}
+
+impl PartialEq for FileType {
+    fn eq(&self, _other: &FileType) -> bool {
+        self.0
+    }
+}
+
+impl Eq for FileType {}
+
+impl Hash for FileType {
+    fn hash<H: Hasher>(&self, _h: &mut H) {
+        self.0
+    }
+}
+
+impl fmt::Debug for FileType {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0
+    }
+}
+
+impl fmt::Debug for ReadDir {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0
+    }
+}
+
+impl Iterator for ReadDir {
+    type Item = io::Result<DirEntry>;
+
+    fn next(&mut self) -> Option<io::Result<DirEntry>> {
+        self.0
+    }
+}
+
+impl DirEntry {
+    pub fn path(&self) -> PathBuf {
+        self.0
+    }
+
+    pub fn file_name(&self) -> OsString {
+        self.0
+    }
+
+    pub fn metadata(&self) -> io::Result<FileAttr> {
+        self.0
+    }
+
+    pub fn file_type(&self) -> io::Result<FileType> {
+        self.0
+    }
+}
+
+impl OpenOptions {
+    pub fn new() -> OpenOptions {
+        OpenOptions {
+            // generic
+            read: false,
+            write: false,
+            append: false,
+            truncate: false,
+            create: false,
+            create_new: false,
+            // system-specific
+            mode: 0o777,
+        }
+    }
+
+    pub fn read(&mut self, read: bool) {
+        self.read = read;
+    }
+    pub fn write(&mut self, write: bool) {
+        self.write = write;
+    }
+    pub fn append(&mut self, append: bool) {
+        self.append = append;
+    }
+    pub fn truncate(&mut self, truncate: bool) {
+        self.truncate = truncate;
+    }
+    pub fn create(&mut self, create: bool) {
+        self.create = create;
+    }
+    pub fn create_new(&mut self, create_new: bool) {
+        self.create_new = create_new;
+    }
+}
+
+impl File {
+    pub fn open(path: &Path, opts: &OpenOptions) -> io::Result<File> {
+        run_path_with_cstr(path, |path| File::open_c(&path, opts))
+    }
+
+    pub fn open_c(path: &CStr, opts: &OpenOptions) -> io::Result<File> {
+        println!("opening 1");
+        let runtime = twizzler_runtime_api::get_runtime();
+        let fd = runtime.open(path);
+
+        Ok(File(FileDesc {
+            fd: fd.unwrap()
+        }))
+    }
+
+    pub fn file_attr(&self) -> io::Result<FileAttr> {
+        Err(Error::from_raw_os_error(22))
+    }
+
+    pub fn fsync(&self) -> io::Result<()> {
+        Err(Error::from_raw_os_error(22))
+    }
+
+    pub fn datasync(&self) -> io::Result<()> {
+        self.fsync()
+    }
+
+    pub fn truncate(&self, _size: u64) -> io::Result<()> {
+        Err(Error::from_raw_os_error(22))
+    }
+
+    pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        crate::io::default_read_vectored(|buf| self.read(buf), bufs)
+    }
+
+    pub fn is_read_vectored(&self) -> bool {
+        false
+    }
+
+    pub fn read_buf(&self, cursor: BorrowedCursor<'_>) -> io::Result<()> {
+        crate::io::default_read_buf(|buf| self.read(buf), cursor)
+    }
+
+    pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        crate::io::default_write_vectored(|buf| self.write(buf), bufs)
+    }
+
+    pub fn is_write_vectored(&self) -> bool {
+        false
+    }
+
+    pub fn flush(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub fn seek(&self, pos: SeekFrom) -> io::Result<u64> {
+        self.0.seek(pos)
+    }
+
+    pub fn duplicate(&self) -> io::Result<File> {
+        Err(Error::from_raw_os_error(22))
+    }
+
+    pub fn set_permissions(&self, _perm: FilePermissions) -> io::Result<()> {
+        Err(Error::from_raw_os_error(22))
+    }
+
+    pub fn set_times(&self, _times: FileTimes) -> io::Result<()> {
+        Err(Error::from_raw_os_error(22))
+    }
+}
+
+impl DirBuilder {
+    pub fn new() -> DirBuilder {
+        println!("Inited DirBuilder! :)");
+        DirBuilder {}
+    }
+
+    pub fn mkdir(&self, _p: &Path) -> io::Result<()> {
+        unsupported()
+    }
+}
+
+impl fmt::Debug for File {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "No")
+    }
+}
+
+pub fn readdir(_p: &Path) -> io::Result<ReadDir> {
+    unsupported()
+}
+
+pub fn unlink(_p: &Path) -> io::Result<()> {
+    unsupported()
+}
+
+pub fn rename(_old: &Path, _new: &Path) -> io::Result<()> {
+    unsupported()
+}
+
+pub fn set_perm(_p: &Path, perm: FilePermissions) -> io::Result<()> {
+    unsupported()
+}
+
+pub fn rmdir(_p: &Path) -> io::Result<()> {
+    unsupported()
+}
+
+pub fn remove_dir_all(_path: &Path) -> io::Result<()> {
+    unsupported()
+}
+
+pub fn try_exists(_path: &Path) -> io::Result<bool> {
+    unsupported()
+}
+
+pub fn readlink(_p: &Path) -> io::Result<PathBuf> {
+    unsupported()
+}
+
+pub fn symlink(_original: &Path, _link: &Path) -> io::Result<()> {
+    unsupported()
+}
+
+pub fn link(_src: &Path, _dst: &Path) -> io::Result<()> {
+    unsupported()
+}
+
+pub fn stat(_p: &Path) -> io::Result<FileAttr> {
+    unsupported()
+}
+
+pub fn lstat(_p: &Path) -> io::Result<FileAttr> {
+    unsupported()
+}
+
+pub fn canonicalize(_p: &Path) -> io::Result<PathBuf> {
+    unsupported()
+}
+
+pub fn copy(_from: &Path, _to: &Path) -> io::Result<u64> {
+    unsupported()
+}

--- a/library/std/src/sys/twizzler/fs.rs
+++ b/library/std/src/sys/twizzler/fs.rs
@@ -225,10 +225,10 @@ impl File {
     pub fn open_c(path: &CStr, opts: &OpenOptions) -> io::Result<File> {
         println!("opening 1");
         let runtime = twizzler_runtime_api::get_runtime();
-        let fd = runtime.open(path);
+        let fd = runtime.open(path)?;
 
         Ok(File(FileDesc {
-            fd: fd.unwrap()
+            fd: fd
         }))
     }
 

--- a/library/std/src/sys/twizzler/fs.rs
+++ b/library/std/src/sys/twizzler/fs.rs
@@ -223,7 +223,6 @@ impl File {
     }
 
     pub fn open_c(path: &CStr, opts: &OpenOptions) -> io::Result<File> {
-        println!("opening 1");
         let runtime = twizzler_runtime_api::get_runtime();
         let fd = runtime.open(path)?;
 
@@ -299,7 +298,6 @@ impl File {
 
 impl DirBuilder {
     pub fn new() -> DirBuilder {
-        println!("Inited DirBuilder! :)");
         DirBuilder {}
     }
 
@@ -310,7 +308,7 @@ impl DirBuilder {
 
 impl fmt::Debug for File {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "No")
+        write!(f, "{}", self.0)
     }
 }
 

--- a/library/std/src/sys/twizzler/mod.rs
+++ b/library/std/src/sys/twizzler/mod.rs
@@ -6,7 +6,8 @@ pub mod args;
 #[path = "../unix/cmath.rs"]
 pub mod cmath;
 pub mod env;
-#[path = "../unsupported/fs.rs"]
+//#[path = "../unsupported/fs.rs"]
+pub mod fd;
 pub mod fs;
 pub mod futex;
 #[path = "../unsupported/io.rs"]

--- a/library/std/src/sys/twizzler/mod.rs
+++ b/library/std/src/sys/twizzler/mod.rs
@@ -6,7 +6,6 @@ pub mod args;
 #[path = "../unix/cmath.rs"]
 pub mod cmath;
 pub mod env;
-//#[path = "../unsupported/fs.rs"]
 pub mod fd;
 pub mod fs;
 pub mod futex;


### PR DESCRIPTION
I've added some code that will interface with the Twizzler runtime. This allows user programs to use the Rust std fs interface to access Twizzler objects.