### PR TITLE
changed link format of backtrace

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,5 +44,5 @@
 	branch = twizzler-dynlink
 [submodule "library/backtrace"]
 	path = library/backtrace
-	url = git@github.com:twizzler-operating-system/backtrace-rs.git
+	url = https://github.com/twizzler-operating-system/backtrace-rs.git
 	branch = twizzler-dynlink


### PR DESCRIPTION
changing from ssh to https so `git submodules update` can run without bothering with ssh key
 this fixes the issue i created on the main twizzler repo here 
 https://github.com/twizzler-operating-system/twizzler/issues/212

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
