### PR TITLE
changed link format of backtrace

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,5 +44,5 @@
 	branch = twizzler-dynlink
 [submodule "library/backtrace"]
 	path = library/backtrace
-	url = git@github.com:twizzler-operating-system/backtrace-rs.git
+	url = https://github.com/twizzler-operating-system/backtrace-rs.git
 	branch = twizzler-dynlink


### PR DESCRIPTION
Sorry i requested to merge to the wrong branch last time, looks like the submodule branch used for the twizzler rust repo is the twizzler branch instead of twizzler-dynlink
![image](https://github.com/user-attachments/assets/41887375-ecac-469e-97e6-4d8d0f4eadf1)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
